### PR TITLE
Catch 'NoneType' errors

### DIFF
--- a/ambihue.py
+++ b/ambihue.py
@@ -6,6 +6,7 @@ import time
 import sys
 from phue import Bridge
 from PIL import ImageGrab
+import logging
 
 __author__ = "Malcolm Crum"
 __license__ = "WTFPL"
@@ -66,6 +67,7 @@ def turnLightToColor(bridge, id, red, green, blue):
 
 
 if __name__ == '__main__':
+    log = logging.getLogger()
     if len(sys.argv) < 2:
         print "Ambient Hue Lighting Controller, by Malcolm Crum"
         print "Usage: python ambihue.py <huehubIP> <lightID>"
@@ -79,5 +81,11 @@ if __name__ == '__main__':
         while True:
             time.sleep(start_time + i * interval - time.time())
             i += 1
-            r, g, b = getAverageScreenColor()
+            try:
+                r, g, b = getAverageScreenColor()
+            except TypeError as exc:
+                # Ocasionally get NoneType fatal errors, this makes them
+                # warnings instead
+                log.warning(exc.message)
+            log.debug('color: red:%s green:%s blue:%s' % (r,g,b))
             turnLightToColor(bridge, int(light), r, g, b)

--- a/run_ambihue.bat
+++ b/run_ambihue.bat
@@ -1,0 +1,2 @@
+python ambihue.py 192.168.1.225 2
+pause


### PR DESCRIPTION
(Feel free to just update file manually. I usually create feature branches when sending pull requests but didn't this time)

When playing guild wars 2 I'd occasionally get an error about 'NoneType' object not iterable when calling `getAverageScreenColor()`.  I haven't been able to reliably reproduce it so instead I "fix" it by logging the exception as warning so it keeps running.  There may be a better fix for it but I didn't spend too much looking in to it and this fixes the symptoms at least.
